### PR TITLE
Update README with install/uninstall instructions 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -44,7 +44,7 @@ git clone https://github.com/uwmisl/poretitioner.git
    
 - You're all set! 
 
-#### Build the application 
+### Build the application 
 
 - Run `nix-build -A app`
 - The poretitioner binary now exists at `./result/bin/poretitioner`
@@ -54,7 +54,7 @@ git clone https://github.com/uwmisl/poretitioner.git
 ./result/bin/poretitioner
 ```
 
-#### Build a docker image of the application 
+### Build a docker image of the application 
 Docker images can only be built on Linux machines. 
 
 - Run 
@@ -64,6 +64,17 @@ Docker images can only be built on Linux machines.
 - The environment variable `docker_image` now contains a path to the docker image, copy this file wherever you need it. 
 
 ```docker load < ${docker_image}```
+
+
+### Uninstall 
+
+To uninstall Nix and this project's dependencies (for example, if you want to wipe your workspace totally clean and start over), run
+
+```
+./boostrap_dev uninstall 
+```
+
+On Mac OS 10.15 (Catalina) and up, this will require some additional steps that the script will elaborate on. 
 
 
 # How it works 


### PR DESCRIPTION
# Description  

- Added installation and uninstallation steps to the README. I placed the User first, since I think they should have to wade through as little text as possible to get started. The steps for developers/contributors come immediately thereafter.

- Added a Continuous Integration badge as a quick visual check that builds are passing. 

# Questions: 

- Is the "How it works" section with the GIF too far below? I'm conflicted because the GIF does an excellent job illustrating what the project does, but its size might obfuscate the "Get Started" directions, and any barrier to getting started can potentially turn users away. 

# Testing 

- Does it look good to you?