### PR TITLE
Prevent uploading artifacts on master builds

### DIFF
--- a/.github/workflows/build_without_artifacts.yml
+++ b/.github/workflows/build_without_artifacts.yml
@@ -25,17 +25,7 @@ jobs:
     - name: Install Nix
       uses: cachix/install-nix-action@v8
     # Runs a set of commands using the runners shell
-    - name: Build docker image 
+    - name: Build application 
       shell: bash
       run: | 
-           mkdir /tmp/artifacts 
-           dockerImagePath=`nix-build -A docker`
-           cp $dockerImagePath /tmp/artifacts/poretitioner_docker.tar.gz
-
-
-    # Uploads the docker image as a build artifact
-    - name: Upload docker image
-      uses: actions/upload-artifact@v1
-      with:
-        name: poretitioner_for_docker
-        path: /tmp/artifacts/poretitioner_docker.tar.gz
+           nix-build -A app


### PR DESCRIPTION
We still build the application to verify mater isn't broken, but we discard the build artifacts to prevent us from exceeding the Github storage limit. 

I'll put a separate PR out to handle uploading artifacts on release, and clean up our old build artifacts.  