### PR TITLE
Build and upload artifacts on release.

### DIFF
--- a/.github/workflows/build_for_release.yml
+++ b/.github/workflows/build_for_release.yml
@@ -1,0 +1,40 @@
+# This is a basic workflow to help you get started with Actions
+
+name: BuildRelease
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ release ]
+  pull_request:
+    branches: [ release ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    - name: Install Nix
+      uses: cachix/install-nix-action@v8
+    # Runs a set of commands using the runners shell
+    - name: Build docker image
+      shell: bash
+      run: |
+           mkdir /tmp/artifacts
+           dockerImagePath=`nix-build -A docker`
+           cp $dockerImagePath /tmp/artifacts/poretitioner_docker.tar.gz
+
+    # Uploads the docker image as a build artifact
+    - name: Upload docker image
+      uses: actions/upload-artifact@v1
+      with:
+        name: poretitioner_docker
+        path: /tmp/artifacts/poretitioner_docker.tar.gz


### PR DESCRIPTION
Only build and upload the docker image for release branches. Still need to figure out where to host the images long-term: https://github.com/uwmisl/poretitioner/issues/9