### PR TITLE
#53 Install pre-commit during bootstrap

### DIFF
--- a/bootstrap_dev.sh
+++ b/bootstrap_dev.sh
@@ -65,7 +65,7 @@ pathToNixEnv () {
     echo "${PORETITIONER_DIR}/nix/env.nix"
 }
 
-if [[ ! -f $(pathToNixEnv) ]]
+if [[ ! -f $(pathToNixEnv) ]];
 then
     yellow "This script requires a PORETITIONER_DIR environment variable, set to the poretitioner repo's path."
     yellow "e.g. PORETITIONER_DIR='$HOME/developer/misl/poretitioner'"
@@ -82,11 +82,11 @@ get () {
     # Finds the *Nix-friendly HTTP GET function. Uses curl if the user has it (MacOS/Linux)
     # or wget if they don't (Linux)
     # Exits if the user has neither (unlikely).
-    if [ -x "$(command -v curl)" ]
+    if [ -x "$(command -v curl)" ];
     then
       echo "curl"
       return
-    elif [ -x "$(command -v wget)" ]
+    elif [ -x "$(command -v wget)" ];
     then
         echo "wget"
         return
@@ -213,7 +213,7 @@ uninstall_clean() {
 }
 
 install_nix () {
-    if [ -x "$(command -v nix)" ];
+    if [ -x "$(command -v nix)" ]
     then
         # Nix is already installed!
         bold "Nix is already installed. Skipping."


### PR DESCRIPTION
## Description 

Installing pre-commit as part of bootstrap (it's already installed via nix, but it needs an extra step to set up the githook)

Please run bootstrap_dev after this is merged. 

## Issues 

#53 

## Testing 

### Test case: Pre-commit is installed during bootstrap 

- From the command line, run `./bootstrap_dev.sh`
- Expected 
  - The line `pre-commit installed at .git/hooks/pre-commit` appears in the output
<img width="419" alt="image" src="https://user-images.githubusercontent.com/14322653/80582123-0b557780-89c3-11ea-8ea0-cec94848ca7a.png">


### Test case: Pre-commit runs when trying to commit 

The main test here is that after running `git commit`, pre-commit will run automatically and check for linting/style.